### PR TITLE
Add start/end controls and countdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@ Open `index.html` in a browser to play.
 Use the left and right arrow keys to move the player and press the space bar to
 shoot at falling targets. Destroying enemies awards points which are displayed
 on the canvas.
+
+Press **Start** to begin a 60‑second round. The remaining time is shown next
+to the controls. Press **End** or wait for the timer to reach zero to stop the
+game.

--- a/css/style.css
+++ b/css/style.css
@@ -4,10 +4,21 @@ body {
     color: #fff;
     font-family: Arial, sans-serif;
     display: flex;
+    flex-direction: column;
+    align-items: center;
     justify-content: center;
 }
 
 #gameCanvas {
     background: #111;
     border: 1px solid #555;
+}
+
+#controls {
+    margin-top: 10px;
+}
+
+#timerDisplay {
+    margin-left: 10px;
+    font-weight: bold;
 }

--- a/index.html
+++ b/index.html
@@ -8,6 +8,11 @@
 </head>
 <body>
     <canvas id="gameCanvas" width="400" height="600"></canvas>
+    <div id="controls">
+        <button id="startBtn">Start</button>
+        <button id="endBtn">End</button>
+        <span id="timerDisplay">Time: 60</span>
+    </div>
     <script src="js/main.js"></script>
 </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,8 @@
 const canvas = document.getElementById('gameCanvas');
 const ctx = canvas.getContext('2d');
+const startBtn = document.getElementById('startBtn');
+const endBtn = document.getElementById('endBtn');
+const timerDisplay = document.getElementById('timerDisplay');
 
 class Player {
     constructor() {
@@ -70,6 +73,10 @@ const keys = {};
 let score = 0;
 let spawnTimer = 0;
 const spawnInterval = 60; // frames
+let running = false;
+let animationId;
+let timerInterval;
+let timeLeft = 60;
 
 function update() {
     player.update();
@@ -124,15 +131,45 @@ function draw() {
     ctx.fillText('Score: ' + score, 10, 20);
 }
 
+function updateTimerDisplay() {
+    timerDisplay.textContent = 'Time: ' + timeLeft;
+}
+
 function gameLoop() {
+    if (!running) return;
     update();
     draw();
-    requestAnimationFrame(gameLoop);
+    animationId = requestAnimationFrame(gameLoop);
+}
+
+function startGame() {
+    if (running) return;
+    running = true;
+    score = 0;
+    spawnTimer = 0;
+    bullets.length = 0;
+    enemies.length = 0;
+    timeLeft = 60;
+    updateTimerDisplay();
+    timerInterval = setInterval(() => {
+        timeLeft--;
+        updateTimerDisplay();
+        if (timeLeft <= 0) {
+            endGame();
+        }
+    }, 1000);
+    animationId = requestAnimationFrame(gameLoop);
+}
+
+function endGame() {
+    running = false;
+    clearInterval(timerInterval);
+    cancelAnimationFrame(animationId);
 }
 
 window.addEventListener('keydown', e => {
     keys[e.key] = true;
-    if (e.key === ' ') {
+    if (e.key === ' ' && running) {
         const bulletX = player.x + player.width / 2 - 2;
         bullets.push(new Bullet(bulletX, player.y));
     }
@@ -142,4 +179,5 @@ window.addEventListener('keyup', e => {
     keys[e.key] = false;
 });
 
-requestAnimationFrame(gameLoop);
+startBtn.addEventListener('click', startGame);
+endBtn.addEventListener('click', endGame);


### PR DESCRIPTION
## Summary
- add Start and End buttons with timer display
- center layout for controls
- implement start/end handlers and one‑minute countdown
- update README to describe controls

## Testing
- `node --check js/main.js`

------
https://chatgpt.com/codex/tasks/task_b_684bd1e2a55083298f036a1ffacd9bc7