### PR TITLE
Add random picker wheel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,18 @@
 # Game
 
 This repository contains a small web‑based shooting game built with
-JavaScript and HTML5 canvas.
-
-Open `index.html` in a browser to play.
+JavaScript and HTML5 canvas. Open `index.html` in a browser to play.
 
 Use the left and right arrow keys to move the player and press the space bar to
 shoot at falling targets. Destroying enemies awards points which are displayed
 on the canvas.
 
-Press **Start** to begin a 60‑second round. The remaining time is shown next
-to the controls. Press **End** or wait for the timer to reach zero to stop the
+Press **Start** to begin a 60‑second round. The remaining time is shown next to
+the controls. Press **End** or wait for the timer to reach zero to stop the
 game.
+
+## Random Picker Wheel
+
+A simple random picker with a spinning wheel is also included. Open
+`wheel.html` to add, remove and spin options. The list of options is stored in
+`localStorage` so your choices are remembered across sessions.

--- a/css/wheel.css
+++ b/css/wheel.css
@@ -1,0 +1,29 @@
+body {
+    font-family: Arial, sans-serif;
+    text-align: center;
+    padding: 20px;
+    background: #222;
+    color: #fff;
+}
+
+canvas {
+    border: 2px solid #555;
+    border-radius: 50%;
+    background: #333;
+}
+
+.controls {
+    margin-top: 10px;
+}
+
+#optionList {
+    list-style: none;
+    padding: 0;
+    margin-top: 10px;
+}
+
+#result {
+    font-size: 1.2em;
+    font-weight: bold;
+    margin-top: 10px;
+}

--- a/js/wheel.js
+++ b/js/wheel.js
@@ -1,0 +1,86 @@
+const canvas = document.getElementById('wheelCanvas');
+const ctx = canvas.getContext('2d');
+const optionInput = document.getElementById('optionInput');
+const addBtn = document.getElementById('addBtn');
+const spinBtn = document.getElementById('spinBtn');
+const optionListEl = document.getElementById('optionList');
+const resultEl = document.getElementById('result');
+
+let options = JSON.parse(localStorage.getItem('wheelOptions')) || ['A', 'B', 'C', 'D'];
+let rotation = 0; // in degrees
+
+function saveOptions() {
+    localStorage.setItem('wheelOptions', JSON.stringify(options));
+}
+
+function drawWheel() {
+    const num = options.length;
+    const arcSize = (2 * Math.PI) / num;
+    const radius = canvas.width / 2;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    for (let i = 0; i < num; i++) {
+        const start = i * arcSize;
+        const end = start + arcSize;
+        ctx.beginPath();
+        ctx.moveTo(radius, radius);
+        ctx.arc(radius, radius, radius, start, end);
+        ctx.closePath();
+        ctx.fillStyle = `hsl(${(i * 360) / num}, 70%, 50%)`;
+        ctx.fill();
+        ctx.save();
+        ctx.translate(radius, radius);
+        ctx.rotate(start + arcSize / 2);
+        ctx.textAlign = 'right';
+        ctx.fillStyle = '#fff';
+        ctx.font = '16px Arial';
+        ctx.fillText(options[i], radius - 10, 5);
+        ctx.restore();
+    }
+}
+
+function updateOptionList() {
+    optionListEl.innerHTML = '';
+    options.forEach((opt, idx) => {
+        const li = document.createElement('li');
+        li.textContent = opt;
+        li.addEventListener('click', () => {
+            options.splice(idx, 1);
+            saveOptions();
+            updateOptionList();
+            drawWheel();
+        });
+        optionListEl.appendChild(li);
+    });
+}
+
+function spin() {
+    if (options.length === 0) return;
+    const extra = Math.random() * 360 + 720; // at least 2 turns
+    rotation = (rotation + extra) % 360;
+    canvas.style.transition = 'transform 4s ease-out';
+    canvas.style.transform = `rotate(${rotation}deg)`;
+    canvas.addEventListener('transitionend', onSpinEnd, { once: true });
+}
+
+function onSpinEnd() {
+    const arc = 360 / options.length;
+    const index = Math.floor(((360 - rotation % 360) % 360) / arc);
+    const choice = options[index];
+    resultEl.textContent = `Result: ${choice}`;
+}
+
+addBtn.addEventListener('click', () => {
+    const val = optionInput.value.trim();
+    if (!val) return;
+    options.push(val);
+    optionInput.value = '';
+    saveOptions();
+    updateOptionList();
+    drawWheel();
+});
+
+spinBtn.addEventListener('click', spin);
+
+// init
+updateOptionList();
+drawWheel();

--- a/wheel.html
+++ b/wheel.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Random Wheel</title>
+    <link rel="stylesheet" href="css/wheel.css">
+</head>
+<body>
+    <h1>Random Picker Wheel</h1>
+    <canvas id="wheelCanvas" width="500" height="500"></canvas>
+    <div class="controls">
+        <input type="text" id="optionInput" placeholder="Add option">
+        <button id="addBtn">Add</button>
+        <button id="spinBtn">Spin</button>
+    </div>
+    <ul id="optionList"></ul>
+    <p id="result"></p>
+
+    <script src="js/wheel.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple wheel-based random picker with localStorage support
- document the new wheel in the README

## Testing
- `npm test` *(fails: Could not read package.json)*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_b_685e316b2eac8329add9bef0f8b1426e